### PR TITLE
Build and deploy image using Semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,23 @@
+#
+# CI pipeline for building the countingup/kinesalite Docker image and pushing to Docker Hub
+#
+name: Build and deploy image
+version: v1.0
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: Build and deploy image
+    task:
+      secrets:
+        - name: countingup-dockerhub
+      jobs:
+        - name: Build and deploy image
+          commands:
+            - checkout
+            - docker build -t countingup/kinesalite .
+            - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
+            - docker push countingup/kinesalite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:12-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-kinesalite"
+
 RUN addgroup kinesalite && adduser -H -D -G kinesalite kinesalite
 
 # See https://github.com/npm/npm/issues/17851 for npm permissions issues when


### PR DESCRIPTION
Use Semaphore to build the image and push to Docker Hub. Replaces Docker Hub's Autobuild, which is becoming unavailable on the free account tier.

Also add a label to the image that Snyk can use to monitor the repo.

[ch982]
